### PR TITLE
disable protected mode

### DIFF
--- a/alpine-redis/root/etc/redis.conf
+++ b/alpine-redis/root/etc/redis.conf
@@ -782,3 +782,5 @@ hz 10
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
+
+protected-mode no


### PR DESCRIPTION
Not sure if this is what you'd like for this image, but it makes using with docker compose much easier. Disabling protected mode allows to make connections to the container from other hosts.